### PR TITLE
Setup Makefile & CI Pipeline to run exercises SQL against Sakila database in MySQL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: "Wait for MySQL to initialize"
         run: |
           curl -LO https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
-          bash wait-for-it.sh --host=localhost --port=$MYSQL_PORT --timeout=30
+          bash wait-for-it.sh localhost:$MYSQL_PORT --timeout=30
       - name: "Import Sakila Database Schema & Data"
         run: |
           CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=MYSQL_PASSWORD"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       MYSQL_USER: mariadb
-      MYSQL_PASSWORD: mriadb-password
+      MYSQL_PASSWORD: mariadb-password
       MYSQL_PORT: 3306
     services:
       mysql:
@@ -30,11 +30,11 @@ jobs:
           tar -xzvf sakila-db.tar.gz
       - name: "Wait for MySQL to initialize"
         run: |
-          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=MYSQL_PASSWORD"
+          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
           while ! echo "SHOW DATABASES;" | mysql ${CONNECTION_OPTS}
           do
             echo "Waiting 5s for MySQL to initialize"
-            sleep 15
+            sleep 5
           done
       - name: "Import Sakila Database Schema & Data"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       MYSQL_USER: mariadb
       MYSQL_PASSWORD: mriadb-password
+      MYSQL_PORT: 3306
     services:
       mysql:
         image: mysql:8.0
@@ -21,14 +22,18 @@ jobs:
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
           MYSQL_ROOT_PASSWORD: root-password
         ports:
-          - 3306:3306
+          - ${{ env.MYSQL_PORT }}:3306
     steps:
       - name: "Download & Extract Sakila Database"
         run: |
           curl -LO https://downloads.mysql.com/docs/sakila-db.tar.gz
           tar -xzvf sakila-db.tar.gz
+      - name: "Wait for MySQL to initialize"
+        run: |
+          curl -LO https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+          bash wait-for-it.sh --host=localhost --port=$MYSQL_PORT --timeout=30
       - name: "Import Sakila Database Schema & Data"
         run: |
-          CONNECTION_OPTS="--host=localhost --protocol=tcp --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }}"
+          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=MYSQL_PASSWORD"
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-schema.sql
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-data.sql

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,5 +38,6 @@ jobs:
           done
       - name: "Import Sakila Database Schema & Data"
         run: |
+          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-schema.sql
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-data.sql

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,7 @@ jobs:
         run: |
           curl -LO https://downloads.mysql.com/docs/sakila-db.tar.gz
           tar -xzvf sakila-db.tar.gz
+      - name: "Import Sakila Database Schema & Data"
+        run: |
+          mysql --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }} < sakila-db/sakila-schema.sql
+          mysql --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }} < sakila-db/sakila-data.sql

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_USER: ${{ env.MYSQL_USER}
+          MYSQL_USER: ${{ env.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
           MYSQL_ROOT_PASSWORD: root-password
         ports:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,13 @@ name: "Learning SQL CI"
 on:
   push: {}
 jobs:
-  setup-sakila-db:
-    name: "CI: Create Sakila Database"
+  run-exercises:
+    name: "CI: Run Exercises"
     runs-on: ubuntu-20.04
     env:
       MYSQL_USER: mariadb
-      MYSQL_PASSWORD: mariadb-password
-      MYSQL_ROOT_PASSWORD: root-password
+      MYSQL_PASSWORD: kx8hquwLaJ73ebN9uFkJ
+      MYSQL_ROOT_PASSWORD: ruR62KHi5eMmHAWTY5Lc
       MYSQL_PORT: 3306
     services:
       mysql:
@@ -41,3 +41,6 @@ jobs:
       - name: "Import Sakila Database Schema & Data"
         run: |
           make load-sakila
+      - name: "Run exercises"
+        run: |
+          make run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
           MYSQL_ROOT_PASSWORD: root-password
         ports:
-          - 3601:3601
+          - 3306:3306
     steps:
       - name: "Download & Extract Sakila Database"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,10 @@ jobs:
         ports:
           - 3306:3306
     steps:
+      - uses: actions/checkout@v2
       - name: "Download & Extract Sakila Database"
         run: |
-          curl -LO https://downloads.mysql.com/docs/sakila-db.tar.gz
-          tar -xzvf sakila-db.tar.gz
+          make download-sakila
       - name: "Wait for MySQL to initialize & Grant all privilleges to 'mariadb' user "
         run: |
           CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=root --password=$MYSQL_ROOT_PASSWORD"
@@ -40,6 +40,4 @@ jobs:
           done
       - name: "Import Sakila Database Schema & Data"
         run: |
-          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
-          mysql ${CONNECTION_OPTS} < sakila-db/sakila-schema.sql
-          mysql ${CONNECTION_OPTS} < sakila-db/sakila-data.sql
+          make load-sakila

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+#
+# learning-sql
+# continuous integation pipeline
+#
+
+name: "Learning SQL CI"
+on:
+  push: {}
+jobs:
+  setup-sakila-db:
+    name: "CI: Create Sakila Database"
+    runs-on: ubuntu-20.04
+    env:
+      MYSQL_USER: mariadb
+      MYSQL_PASSWORD: mriadb-password
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_USER: ${{ env.MYSQL_USER}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: root-password
+        ports:
+          - 3601:3601

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       MYSQL_USER: mariadb
       MYSQL_PASSWORD: mariadb-password
+      MYSQL_ROOT_PASSWORD: root-password
       MYSQL_PORT: 3306
     services:
       mysql:
@@ -20,7 +21,7 @@ jobs:
         env:
           MYSQL_USER: ${{ env.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
-          MYSQL_ROOT_PASSWORD: root-password
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
         ports:
           - 3306:3306
     steps:
@@ -28,10 +29,11 @@ jobs:
         run: |
           curl -LO https://downloads.mysql.com/docs/sakila-db.tar.gz
           tar -xzvf sakila-db.tar.gz
-      - name: "Wait for MySQL to initialize"
+      - name: "Wait for MySQL to initialize & Grant all privilleges to 'mariadb' user "
         run: |
-          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
-          while ! echo "SHOW DATABASES;" | mysql ${CONNECTION_OPTS}
+          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=root --password=$MYSQL_ROOT_PASSWORD"
+          # while loop required to poll MySQL until it finishes initialization
+          while ! echo "GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%';" | mysql ${CONNECTION_OPTS}
           do
             echo "Waiting 5s for MySQL to initialize"
             sleep 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,8 @@ jobs:
           MYSQL_ROOT_PASSWORD: root-password
         ports:
           - 3601:3601
+    steps:
+      - name: "Download & Extract Sakila Database"
+        run: |
+          curl -LO https://downloads.mysql.com/docs/sakila-db.tar.gz
+          tar -xzvf sakila-db.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,13 @@ jobs:
           tar -xzvf sakila-db.tar.gz
       - name: "Wait for MySQL to initialize"
         run: |
-          curl -LO https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
-          bash wait-for-it.sh localhost:$MYSQL_PORT --timeout=30
+          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=MYSQL_PASSWORD"
+          while ! echo "SHOW DATABASES;" | mysql ${CONNECTION_OPTS}
+          do
+            echo "Waiting 5s for MySQL to initialize"
+            sleep 15
+          done
       - name: "Import Sakila Database Schema & Data"
         run: |
-          CONNECTION_OPTS="--host=localhost --port=$MYSQL_PORT --protocol=tcp --user=$MYSQL_USER --password=MYSQL_PASSWORD"
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-schema.sql
           mysql ${CONNECTION_OPTS} < sakila-db/sakila-data.sql

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
           MYSQL_ROOT_PASSWORD: root-password
         ports:
-          - ${{ env.MYSQL_PORT }}:3306
+          - 3306:3306
     steps:
       - name: "Download & Extract Sakila Database"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,6 @@ jobs:
           tar -xzvf sakila-db.tar.gz
       - name: "Import Sakila Database Schema & Data"
         run: |
-          mysql --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }} < sakila-db/sakila-schema.sql
-          mysql --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }} < sakila-db/sakila-data.sql
+          CONNECTION_OPTS="--host=localhost --protocol=tcp --user=${{ env.MYSQL_USER}} --password=${{ env.MYSQL_PASSWORD }}"
+          mysql ${CONNECTION_OPTS} < sakila-db/sakila-schema.sql
+          mysql ${CONNECTION_OPTS} < sakila-db/sakila-data.sql

--- a/exercises/chapter_3/exercise_1.sql
+++ b/exercises/chapter_3/exercise_1.sql
@@ -1,0 +1,11 @@
+--
+-- Learning SQL
+-- Exercises: Chapter 3-1
+--
+
+SELECT
+  actor_id, first_name, last_name
+FROM
+  actor
+ORDER BY
+  last_name, first_name

--- a/makefile
+++ b/makefile
@@ -9,19 +9,19 @@ CURL:=curl
 TAR:=tar
 
 # path
-SAKILA_DIR:=/tmp/sakila-db
+SAKILA_DIR?=/tmp/sakila-db
 
 # MySql connection parameters
 # target host & port mysql to connect to
-MYSQL_HOST:=localhost
-MYSQL_PORT:=3306
+MYSQL_HOST?=localhost
+MYSQL_PORT?=3306
 # protocol used to communicate with mysql
-MYSQL_PROTOCOL:=tcp
+MYSQL_PROTOCOL?=tcp
 # mysql database to use. This should be 'sakila' when completin exercises.
-MYSQL_DATABASE:=sakila
+MYSQL_DATABASE?=sakila
 # user credentials to use to authenticate with MySQL.
-MYSQL_USER:=mariadb
-MYSQL_PASSWORD:=mariadb-password
+MYSQL_USER?=mariadb
+MYSQL_PASSWORD?=mariadb-password
 
 # shorthand for running mysql client with connection params
 MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
@@ -29,7 +29,9 @@ MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 	--protocol=$(MYSQL_PROTOCOL) \
 	--password=$(MYSQL_PASSWORD) sakila <exercises/chapter_3/exercise_1.sql
 
-.PHONY: init-sakila
+.PHONY: download-sakila init-sakila
+
+download-sakila: $(SAKILA_DIR)
 
 $(SAKILA_DIR):
 	$(CURL) -k https://downloads.mysql.com/docs/sakila-db.tar.gz -o $(SAKILA_DIR).tgz

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 	--protocol=$(MYSQL_PROTOCOL) \
 	--password=$(MYSQL_PASSWORD)
 
-.PHONY: download-sakila init-sakila
+.PHONY: download-sakila load-sakila sakila-data sakila-schema
 
 download-sakila: $(SAKILA_DIR)
 
@@ -37,6 +37,10 @@ $(SAKILA_DIR):
 	$(CURL) -k https://downloads.mysql.com/docs/sakila-db.tar.gz -o $(SAKILA_DIR).tgz
 	$(TAR) -C $(dir $(SAKILA_DIR)) -xzvf $(SAKILA_DIR).tgz
 
-load-sakila: $(SAKILA_DIR)
+load-sakila: sakila-schema sakila-data
+
+sakila-schema: $(SAKILA_DIR)
 	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-schema.sql
+
+sakila-data: $(SAKILA_DIR)
 	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql

--- a/makefile
+++ b/makefile
@@ -8,8 +8,10 @@ MYSQL:=mysql
 CURL:=curl
 TAR:=tar
 
-# path
+# path aliases
 SAKILA_DIR?=/tmp/sakila-db
+# exercise SQL files as defined as any '.sql' with a 'exercise' prefix
+EXERCISE_SQLS:=$(shell find -type f -name 'exercise*.sql')
 
 # MySql connection parameters
 # target host & port mysql to connect to
@@ -26,11 +28,14 @@ MYSQL_PASSWORD?=mariadb-password
 # shorthand for running mysql client with connection params
 MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 	--user=$(MYSQL_USER) \
+	--password=$(MYSQL_PASSWORD) \
 	--protocol=$(MYSQL_PROTOCOL) \
-	--password=$(MYSQL_PASSWORD)
 
-.PHONY: download-sakila load-sakila sakila-data sakila-schema
 
+.PHONY: download-sakila load-sakila sakila-data sakila-schema run
+	$(RUN_EXERCISES)
+
+# section: targets to download, load the Sakila database
 download-sakila: $(SAKILA_DIR)
 
 $(SAKILA_DIR):
@@ -44,3 +49,11 @@ sakila-schema: $(SAKILA_DIR)
 
 sakila-data: $(SAKILA_DIR)
 	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql
+
+
+RUN_EXERCISES:=$(foreach SQL,$(EXERCISE_SQLS),run/$(SQL))
+
+run: $(RUN_EXERCISES)
+
+run/%.sql: %.sql
+	$(MYSQL_RUN) sakila <$<

--- a/makefile
+++ b/makefile
@@ -32,17 +32,25 @@ MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 	--protocol=$(MYSQL_PROTOCOL) \
 
 
-.PHONY: download-sakila load-sakila sakila-data sakila-schema run
-	$(RUN_EXERCISES)
+.PHONY: download-sakila load-sakila sakila-data sakila-schema run $(RUN_EXERCISES) \
+	debug
 
 .DEFAULT: run
 
+# section: targets to run & debug exercises
 RUN_EXERCISES:=$(foreach SQL,$(EXERCISE_SQLS),run/$(SQL))
 
 run: $(RUN_EXERCISES)
 
 run/%.sql: %.sql
-	$(MYSQL_RUN) sakila <$<
+	@$(MYSQL_RUN) sakila < $<
+
+# 'debug/%' adds to the 'run/%' target by providing features for easiler debugging:
+# - file header
+# - result set in pretty formatted tables.
+# - scrollable output.
+debug/%.sql: %.sql
+	@(echo "============[$@]============"; $(MYSQL_RUN) --table sakila < $< )| less
 
 # section: targets to download, load the Sakila database
 download-sakila: $(SAKILA_DIR)

--- a/makefile
+++ b/makefile
@@ -35,6 +35,15 @@ MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 .PHONY: download-sakila load-sakila sakila-data sakila-schema run
 	$(RUN_EXERCISES)
 
+.DEFAULT: run
+
+RUN_EXERCISES:=$(foreach SQL,$(EXERCISE_SQLS),run/$(SQL))
+
+run: $(RUN_EXERCISES)
+
+run/%.sql: %.sql
+	$(MYSQL_RUN) sakila <$<
+
 # section: targets to download, load the Sakila database
 download-sakila: $(SAKILA_DIR)
 
@@ -49,11 +58,3 @@ sakila-schema: $(SAKILA_DIR)
 
 sakila-data: $(SAKILA_DIR)
 	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql
-
-
-RUN_EXERCISES:=$(foreach SQL,$(EXERCISE_SQLS),run/$(SQL))
-
-run: $(RUN_EXERCISES)
-
-run/%.sql: %.sql
-	$(MYSQL_RUN) sakila <$<

--- a/makefile
+++ b/makefile
@@ -43,12 +43,9 @@ RUN_EXERCISES:=$(foreach SQL,$(EXERCISE_SQLS),run/$(SQL))
 run: $(RUN_EXERCISES)
 
 run/%.sql: %.sql
-	@$(MYSQL_RUN) sakila < $<
+	@(echo "============[$@]============"; $(MYSQL_RUN) --table sakila < $< )
 
-# 'debug/%' adds to the 'run/%' target by providing features for easiler debugging:
-# - file header
-# - result set in pretty formatted tables.
-# - scrollable output.
+# 'debug/%' adds to the 'run/%' target by providing scrollable output for easiler debugging.
 debug/%.sql: %.sql
 	@(echo "============[$@]============"; $(MYSQL_RUN) --table sakila < $< )| less
 
@@ -62,7 +59,7 @@ $(SAKILA_DIR):
 load-sakila: sakila-schema sakila-data
 
 sakila-schema: $(SAKILA_DIR)
-	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-schema.sql
+	@$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-schema.sql
 
 sakila-data: $(SAKILA_DIR)
-	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql
+	@$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ MYSQL_PASSWORD?=mariadb-password
 MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
 	--user=$(MYSQL_USER) \
 	--protocol=$(MYSQL_PROTOCOL) \
-	--password=$(MYSQL_PASSWORD) sakila <exercises/chapter_3/exercise_1.sql
+	--password=$(MYSQL_PASSWORD)
 
 .PHONY: download-sakila init-sakila
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,40 @@
+#
+# learning-sql
+# project makefile
+#
+
+# program aliases
+MYSQL:=mysql
+CURL:=curl
+TAR:=tar
+
+# path
+SAKILA_DIR:=/tmp/sakila-db
+
+# MySql connection parameters
+# target host & port mysql to connect to
+MYSQL_HOST:=localhost
+MYSQL_PORT:=3306
+# protocol used to communicate with mysql
+MYSQL_PROTOCOL:=tcp
+# mysql database to use. This should be 'sakila' when completin exercises.
+MYSQL_DATABASE:=sakila
+# user credentials to use to authenticate with MySQL.
+MYSQL_USER:=mariadb
+MYSQL_PASSWORD:=mariadb-password
+
+# shorthand for running mysql client with connection params
+MYSQL_RUN:=$(MYSQL) --host=$(MYSQL_HOST) --port=$(MYSQL_PORT) \
+	--user=$(MYSQL_USER) \
+	--protocol=$(MYSQL_PROTOCOL) \
+	--password=$(MYSQL_PASSWORD) sakila <exercises/chapter_3/exercise_1.sql
+
+.PHONY: init-sakila
+
+$(SAKILA_DIR):
+	$(CURL) -k https://downloads.mysql.com/docs/sakila-db.tar.gz -o $(SAKILA_DIR).tgz
+	$(TAR) -C $(dir $(SAKILA_DIR)) -xzvf $(SAKILA_DIR).tgz
+
+load-sakila: $(SAKILA_DIR)
+	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-schema.sql
+	$(MYSQL_RUN) < $(SAKILA_DIR)/sakila-data.sql


### PR DESCRIPTION
Setup Makefile & CI Pipeline to run exercises SQL against Sakila database in MySQL:
- resolves: #1 
- Adds a Project Makefile to automate common tasks:
   - Download Sakila database, loading data, schema into MySQL.
   - Run exercise files with pretty formatted table output.
   - Debug target run exercises with `less` for scrollable output. 
- Adds a Github Actions CI pipeline to run exercise files:
   - Uses services to bootstrap a fresh MySQL container.
   - Uses Project Makefile to load Sakila database into MySQL instance.
   - Users Project Makefile to run exercise SQL files against Sakila database.